### PR TITLE
Disable strictNullChecks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,7 +76,7 @@
         /* Type Checking */
         "strict": true /* Enable all strict type-checking options. */,
         "noImplicitAny": false /* Enable error reporting for expressions and declarations with an implied `any` type.. */,
-        // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+        "strictNullChecks": false /* When type checking, take into account `null` and `undefined`. */,
         // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
         // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
         // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */


### PR DESCRIPTION
`strictNullChecks` が有効だと毎回 null チェックしないといけないのでハードルが高い